### PR TITLE
Add injection selectors for embedded grammar

### DIFF
--- a/grammars/m.cson
+++ b/grammars/m.cson
@@ -2,6 +2,8 @@ fileTypes: [
   "m"
 ]
 name: "MATLAB"
+scopeName: "source.matlab"
+injectionSelector: "source.embedded.matlab"
 patterns: [
   {
     include: "#classdef"
@@ -1034,4 +1036,3 @@ repository:
     comment: "No variables or function names can start with a number or an underscore."
     match: "\\b(_\\w|\\d+[_a-df-zA-DF-Z])\\w*\\b"
     name: "invalid.illegal.invalid-variable-name.matlab"
-scopeName: "source.matlab"

--- a/grammars/octave.cson
+++ b/grammars/octave.cson
@@ -2,6 +2,8 @@ fileTypes: [
   "m"
 ]
 name: "Octave"
+scopeName: "source.octave"
+injectionSelector: "source.embedded.octave"
 patterns: [
   {
     begin: '''
@@ -390,4 +392,3 @@ repository:
     comment: "No variables or function names can start with a number or an underscore."
     match: "\\b(_\\w|\\d+[_a-df-zA-DF-Z])\\w*\\b"
     name: "invalid.illegal.invalid-variable-name.octave"
-scopeName: "source.octave"


### PR DESCRIPTION
This grammar can automatically embed itself when the `injectionSelector` scope is found in another grammar. 

For example, `language-hyperlink` uses `'text - string.regexp, string - string.regexp, comment, source.gfm'` (the `-` sign means the following scope is not allowed; so it injects in `text`, but not when also in `string.regexp`). This allows hyperlinks to be scoped independently of the main grammar.

Likewise, this change will allow grammars such as `language-gfm` to automatically embed this one when something like the following occurs
````
```matlab
<matlab code>
```
````
In cases like this, when there is no hardcoded treatment of the language name, `language-gfm` will default to trying to include `source.embedded.<language_name>`, hence why I made the injection selector `source.embedded.matlab`.


I did this to octave too, and also moved the `scopeName` property to the top, where it is visible.