### PR TITLE
:bug: Ensure proper highlighting of 'otherwise'

### DIFF
--- a/grammars/m.cson
+++ b/grammars/m.cson
@@ -239,7 +239,7 @@ repository:
             name: "meta.case.matlab"
           }
           {
-            beginCaptures:
+            captures:
               "0":
                 name: "meta.otherwise-expression.matlab"
               "2":


### PR DESCRIPTION
+ Keyword 'otherwise' would not be recognized as such, because of an unclosed beginCaptures block. 
+ Replace beginCaptures block with captures block

This is the first time with CSON for me and even tough it works for me, I'm not entirely sure that what I did is correct. 